### PR TITLE
fix: Handle when block has no properties

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -848,7 +848,7 @@ async function getChildren(uuid, property, coverProp, configs) {
   }
 
   const filtered = dbResult.filter(
-    (block) => block.properties[property] && !block.properties.archived,
+    (block) => block.properties && block.properties[property] && !block.properties.archived,
   )
   for (const block of filtered) {
     if (Array.isArray(block.properties[property])) {


### PR DESCRIPTION
It seems that not every block necessarily has a `properties` property.
In my LogSeq query, the `dbResults` array has 4 elements which do have `properties`, but 1 that doesn't, which makes the plugin crash.