### PR TITLE
fix(utils): tags split regex and empty element filter

### DIFF
--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -18,7 +18,7 @@ export async function parseContent(content, coverProp = "cover") {
   const tagsPropIndex = props.findIndex(([k]) => k === "tags")
   if (tagsPropIndex > -1) {
     const [, tagsPropValue] = props[tagsPropIndex]
-    for (const t of tagsPropValue.split(/,，/)) {
+    for (const t of tagsPropValue.split(/[,， ]/).filter(e => e)) {
       tags.add(t.replace(/^\s*\[\[((?:[^\]]|\](?!\]))+)\]\]\s*$/, "$1"))
     }
     props.splice(tagsPropIndex, 1)


### PR DESCRIPTION
This fixes the regex for splitting the tags of a card, in so that they display as separate coloured boxes.

![grafik](https://github.com/sethyuan/logseq-plugin-kanban-board/assets/1645308/28528b6d-f542-46fc-a71f-ed128e214c45)

The additional `.filter()` removes empty arrays, e.g. when multiple commata or spaces occur after one another.

![Bildschirmfoto vom 2023-11-15 01-55-00](https://github.com/sethyuan/logseq-plugin-kanban-board/assets/1645308/178f4764-53cb-4709-ac94-95fc7639792d)

Closes #16